### PR TITLE
add/addMany function add 'replace' options

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -109,7 +109,7 @@ declare namespace ThinkModel {
     /**
      * add data
      */
-    add(data: object, options?: object): Promise<string>;
+    add(data: object, options?: object, replace?: boolean): Promise<string>;
 
     /**
      * add data when not exist
@@ -126,7 +126,7 @@ declare namespace ThinkModel {
     /**
      * add multi data
      */
-    addMany(data: Array<object>, options?: object): Promise<Array<string>>;
+    addMany(data: Array<object>, options?: object, replace?: boolean): Promise<Array<string>>;
 
     /**
      * delete data

--- a/src/model.js
+++ b/src/model.js
@@ -419,12 +419,12 @@ module.exports = class Model {
    * @param {Object} data
    * @param {Object} options
    */
-  async add(data, options) {
+  async add(data, options, replace) {
     options = await this.parseOptions(options);
     let parsedData = await this.db().parseData(data, false, options.table);
     parsedData = await this.beforeAdd(parsedData, options);
     if (helper.isEmpty(parsedData)) return Promise.reject(new Error('add data is empty'));
-    const lastInsertId = await this.db().add(parsedData, options);
+    const lastInsertId = await this.db().add(parsedData, options, replace);
     const copyData = Object.assign({}, data, parsedData, {[this.pk]: lastInsertId});
     await this.afterAdd(copyData, options);
     return lastInsertId;
@@ -464,7 +464,7 @@ module.exports = class Model {
    * @param {} options []
    * @param {} replace []
    */
-  async addMany(data, options) {
+  async addMany(data, options, replace) {
     if (!helper.isArray(data) || !helper.isObject(data[0])) {
       return Promise.reject(new Error('data must be an array'));
     }
@@ -474,7 +474,7 @@ module.exports = class Model {
       return this.beforeAdd(item, options);
     });
     data = await Promise.all(promises);
-    const insertIds = await this.db().addMany(data, options);
+    const insertIds = await this.db().addMany(data, options, replace);
     promises = data.map((item, i) => {
       item[this.pk] = insertIds[i];
       return this.afterAdd(item, options);


### PR DESCRIPTION
thinkjs2 的 add/addMany 方法有 replace选项，实现replace into 语句，thinkjs3的函数没有这个选项，导致，碰到明确的替代式插入，每次插入前都必须查询一遍，多一次数据库操作，特别是批量插入时，增加的数据语句非常大，比如批量导入含唯一索引的数据、格式化数据表、迁移数据表时，原来只要一条addMany(data, null, true) , 现在都不得不在addMany失败时调用thenUpate一条一条插入，所以强烈建议恢复这个选择项