### PR TITLE
[feat] parse JSON data when jsonFormat is true

### DIFF
--- a/src/model.js
+++ b/src/model.js
@@ -387,7 +387,15 @@ module.exports = class Model {
    * after find
    * @return {} []
    */
-  afterFind(data) {
+  async afterFind(data) {
+    if (this.config.jsonFormat) {
+      const schema = await this.db().getSchema();
+      Object.keys(schema)
+        .filter(key => data[key] !== undefined && schema[key].tinyType === 'json')
+        .forEach(key => {
+          data[key] = JSON.parse(data[key]);
+        });
+    }
     return this[RELATION].afterFind(data);
   }
   /**
@@ -401,7 +409,17 @@ module.exports = class Model {
    * @param  {Mixed} result []
    * @return {}        []
    */
-  afterSelect(data) {
+  async afterSelect(data) {
+    if (this.config.jsonFormat) {
+      const schema = await this.db().getSchema();
+      const keys = Object.keys(schema).filter(key => schema[key].tinyType === 'json');
+      data.forEach(row => {
+        keys.filter(key => row[key] !== undefined).forEach(key => {
+          row[key] = JSON.parse(row[key]);
+        });
+      });
+    }
+
     return this[RELATION].afterSelect(data);
   }
   /**

--- a/test/model.js
+++ b/test/model.js
@@ -516,6 +516,39 @@ test('model find data', async t => {
   t.deepEqual(result, data);
 });
 
+test('model afterFind parse json data', async t => {
+  const data = {title: 'hello', content: 'world', json: JSON.stringify([1,2,3,4])};
+  class PostModel extends Model {
+    async afterFind(findData) {
+      findData = await Model.prototype.afterFind.call(this, findData);
+      t.deepEqual(findData, {title: 'hello', content: 'world', json: [1,2,3,4]});
+    }
+  }
+
+  const model = new PostModel('post', {
+    handle: class {
+      getSchema() {
+        return {
+          title: {
+            tinyType: 'varchar'
+          },
+          content: {
+            tinyType: 'varchar'
+          },
+          json: {
+            tinyType: 'json'
+          }
+        }
+      }
+      select() {
+        return [data];
+      }
+    },
+    jsonFormat: true
+  });
+  await model.where({id: 3}).limit([0, 10]).find();
+});
+
 test('model select data', async t => {
   t.plan(5);
 
@@ -545,6 +578,39 @@ test('model select data', async t => {
   };
   const result = await model.where({id: ['>', 10]}).select();
   t.deepEqual(result, data);
+});
+
+test('model afterSelect parse json data', async t => {
+  const data = [{title: 'hello', content: 'world', json: JSON.stringify([1,2,3,4])}];
+  class PostModel extends Model {
+    async afterSelect(selectData) {
+      selectData = await Model.prototype.afterSelect.call(this, selectData);
+      t.deepEqual(selectData, [{title: 'hello', content: 'world', json: [1,2,3,4]}]);
+    }
+  }
+
+  const model = new PostModel('post', {
+    handle: class {
+      getSchema() {
+        return {
+          title: {
+            tinyType: 'varchar'
+          },
+          content: {
+            tinyType: 'varchar'
+          },
+          json: {
+            tinyType: 'json'
+          }
+        }
+      }
+      select() {
+        return data;
+      }
+    },
+    jsonFormat: true
+  });
+  await model.where('1=1').select();
 });
 
 test.todo('selectAdd');


### PR DESCRIPTION
It can make `think-model` module output JSON data when column type is json, that's better than before. close https://github.com/thinkjs/thinkjs/issues/1511 when pr merged.

- [x] add `JSON.parse` when `find()` and `select()`
- [x] add `JSON.stringify` when `add()` and `update()`