### PR TITLE
fix(countSelect):  execute count unexpectly

### DIFF
--- a/src/model.js
+++ b/src/model.js
@@ -639,7 +639,7 @@ module.exports = class Model {
     const order = options.order;
     delete options.order;
 
-    if (!count) {
+    if (!count && count !== 0) {
       this.options = options;
       count = await this.count(`${this[QUOTE_FIELD](table)}.${this.pk}`);
     }


### PR DESCRIPTION
修复 `countSelect` 方法在指定 `total` 后，仍然会非预期地执行默认的 `count` 语句的问题。