### PR TITLE
Bugfix: MANY_TO_MANY 联表查询时字段名称重复会报错，需要增加别名前缀

### DIFF
--- a/lib/relation/base.js
+++ b/lib/relation/base.js
@@ -16,8 +16,9 @@ module.exports = class BaseRelation {
   }
   /**
    * parse where in relation model
+   * @param {String} prefix prefix for table alia name
    */
-  parseRelationWhere() {
+  parseRelationWhere(prefix) {
     const { key, fKey } = this.options;
     if (helper.isArray(this.data)) {
       const keys = [];
@@ -29,12 +30,12 @@ module.exports = class BaseRelation {
       });
       if (keys.length === 0) return false;
       return {
-        [fKey]: ['IN', keys]
+        [prefix + fKey]: ['IN', keys]
       };
     }
     if (!this.data[key]) return false;
     return {
-      [fKey]: this.data[key]
+      [prefix + fKey]: this.data[key]
     };
   }
   /**

--- a/lib/relation/base.js
+++ b/lib/relation/base.js
@@ -18,7 +18,7 @@ module.exports = class BaseRelation {
    * parse where in relation model
    * @param {String} prefix prefix for table alia name
    */
-  parseRelationWhere(prefix) {
+  parseRelationWhere(prefix = '') {
     const { key, fKey } = this.options;
     if (helper.isArray(this.data)) {
       const keys = [];

--- a/lib/relation/many_to_many.js
+++ b/lib/relation/many_to_many.js
@@ -20,7 +20,7 @@ module.exports = class ManyToManyRelation extends BaseRelation {
     var _this = this;
 
     return _asyncToGenerator(function* () {
-      const where = _this.parseRelationWhere();
+      const where = _this.parseRelationWhere('b.');
       if (where === false) return _this.data;
       const relationModel = _this.options.rModel || _this.getRelationModelName();
       const rfKey = _this.options.rfKey || `${_this.options.model.modelName}_id`;

--- a/src/relation/base.js
+++ b/src/relation/base.js
@@ -18,7 +18,7 @@ module.exports = class BaseRelation {
    * parse where in relation model
    * @param {String} prefix prefix for table alia name
    */
-  parseRelationWhere(prefix) {
+  parseRelationWhere(prefix = '') {
     const {key, fKey} = this.options;
     if (helper.isArray(this.data)) {
       const keys = [];

--- a/src/relation/base.js
+++ b/src/relation/base.js
@@ -16,8 +16,9 @@ module.exports = class BaseRelation {
   }
   /**
    * parse where in relation model
+   * @param {String} prefix prefix for table alia name
    */
-  parseRelationWhere() {
+  parseRelationWhere(prefix) {
     const {key, fKey} = this.options;
     if (helper.isArray(this.data)) {
       const keys = [];
@@ -29,12 +30,12 @@ module.exports = class BaseRelation {
       });
       if (keys.length === 0) return false;
       return {
-        [fKey]: ['IN', keys]
+        [prefix + fKey]: ['IN', keys]
       };
     }
     if (!this.data[key]) return false;
     return {
-      [fKey]: this.data[key]
+      [prefix + fKey]: this.data[key]
     };
   }
   /**

--- a/src/relation/many_to_many.js
+++ b/src/relation/many_to_many.js
@@ -15,7 +15,7 @@ module.exports = class ManyToManyRelation extends BaseRelation {
    * relation on select or find
    */
   async getRelationData() {
-    const where = this.parseRelationWhere();
+    const where = this.parseRelationWhere('b.');
     if (where === false) return this.data;
     const relationModel = this.options.rModel || this.getRelationModelName();
     const rfKey = this.options.rfKey || `${this.options.model.modelName}_id`;

--- a/test/relation/many_to_many.js
+++ b/test/relation/many_to_many.js
@@ -62,7 +62,7 @@ test('many to many get relation get modelName from rModel', async t => {
 
   relation.model = relation.options.model = new Model('user', {handle: new Function()});
   relation.options.model.select = function() {
-    t.deepEqual(this.options, {'field': '*,b.post_id', 'fieldReverse': false, 'alias': 'a', 'where': {'post_id': ['IN', [3, 10]]}, 'join': [{'post_user': {'table': 'relationModel', 'as': 'b', 'join': 'inner', 'on': ['id', 'user_id']}}]});
+    t.deepEqual(this.options, {'field': '*,b.post_id', 'fieldReverse': false, 'alias': 'a', 'where': {'b.post_id': ['IN', [3, 10]]}, 'join': [{'post_user': {'table': 'relationModel', 'as': 'b', 'join': 'inner', 'on': ['id', 'user_id']}}]});
     return [
       {name: 'lizheming', post_id: 10},
       {name: 'lizheming1', post_id: 10},


### PR DESCRIPTION
例如：当role表和user_role表中也都user_id字段时会报错

这句会报错：Error: ER_NON_UNIQ_ERROR: Column 'user_id' in where clause is ambiguous
```sql
SELECT `a`.*,b.user_id FROM `think_role` AS a 
INNER JOIN `think_user_role` AS `b` ON `a`.`id` = `b`.`role_id` 
WHERE ( user_id = 862619060 )
```

这句是这个PR修改之后的效果
```sql
SELECT `a`.*,b.user_id FROM `think_role` AS a 
INNER JOIN `think_user_role` AS `b` ON `a`.`id` = `b`.`role_id` 
WHERE ( b.user_id = 862619060 )
```